### PR TITLE
Add several cookie retention policies to `useShopifyCookies`

### DIFF
--- a/packages/react/src/useShopifyCookies.tsx
+++ b/packages/react/src/useShopifyCookies.tsx
@@ -33,12 +33,13 @@ export const ALL_POLICIES: Set<NoConsentCookiePolicy> = new Set([
  * token cookie for 1 year; otherwise, do what policyForNoConsent specifies
  * @param domain - The domain scope of the cookie
  * @param policyForNoConsent - One of POLICY_NO_COOKIE, POLICY_SESSIONIZED, POLICY_SHORT_TERM:
- * how to set cookies if no consent given
+ * what to do if no consent given
  * @example
  * ```tsx
- * import {useShopifyCookies} from '@shopify/storefront-kit-react';
+ * import {useShopifyCookies, POLICY_NO_COOKIE} from '@shopify/hydrogen-react';
  *
- * useShopifyCookies(true, 'my-shop.com')
+ * useShopifyCookies(true, 'my-shop.com', )
+ * useShopifyCookies(false, 'my-shop.com', POLICY_NO_COOKIE)
  * ```
  */
 

--- a/packages/react/src/useShopifyCookies.tsx
+++ b/packages/react/src/useShopifyCookies.tsx
@@ -7,10 +7,33 @@ const longTermLength = 60 * 60 * 24 * 360 * 1; // ~1 year expiry
 const shortTermLength = 60 * 30; // 30 mins
 
 /**
+ * If no consent given:
+ * POLICY_NO_COOKIE: Do not set a cookie
+ * POLICY_SESSIONIZED: Set a session cookie
+ * POLICY_SHORT_TERM: Set a short-term cookie
+ */
+
+export type NoConsentCookiePolicy =
+  | 'POLICY_NO_COOKIE'
+  | 'POLICY_SESSIONIZED'
+  | 'POLICY_SHORT_TERM';
+
+export const POLICY_NO_COOKIE: NoConsentCookiePolicy = 'POLICY_NO_COOKIE';
+export const POLICY_SESSIONIZED: NoConsentCookiePolicy = 'POLICY_SESSIONIZED';
+export const POLICY_SHORT_TERM: NoConsentCookiePolicy = 'POLICY_SHORT_TERM';
+export const ALL_POLICIES: Set<NoConsentCookiePolicy> = new Set([
+  POLICY_NO_COOKIE,
+  POLICY_SESSIONIZED,
+  POLICY_SHORT_TERM,
+]);
+
+/**
  * Set user and session cookies and refresh the expiry time
  * @param hasUserConsent - Defaults to false. If hasUserConsent is true, we can set Shopify unique user
- * token cookie from expiry of 30 mins to 1 year
+ * token cookie for 1 year; otherwise, do what policyForNoConsent specifies
  * @param domain - The domain scope of the cookie
+ * @param policyForNoConsent - One of POLICY_NO_COOKIE, POLICY_SESSIONIZED, POLICY_SHORT_TERM:
+ * how to set cookies if no consent given
  * @example
  * ```tsx
  * import {useShopifyCookies} from '@shopify/storefront-kit-react';
@@ -18,9 +41,43 @@ const shortTermLength = 60 * 30; // 30 mins
  * useShopifyCookies(true, 'my-shop.com')
  * ```
  */
-export function useShopifyCookies(hasUserConsent = false, domain = ''): void {
+
+export const DEFAULT_NO_CONSENT_POLICY = POLICY_SHORT_TERM;
+export function useShopifyCookies(
+  hasUserConsent = false,
+  domain = '',
+  policyForNoConsent: NoConsentCookiePolicy = DEFAULT_NO_CONSENT_POLICY
+): void {
   useEffect(() => {
+    let policy: NoConsentCookiePolicy = policyForNoConsent;
+    /**
+     * Even though TypeScript wouldn't allow this, the library may end up
+     * being called in a non-TS world, and we have to fall back to the
+     * compliant choice.
+     */
+
+    if (!ALL_POLICIES.has(policyForNoConsent)) {
+      policy = DEFAULT_NO_CONSENT_POLICY;
+    }
+
+    /**
+     * Choose how to deal with no consent given.
+     * This is done with the assumption we DON'T get consent.
+     */
+    if (!hasUserConsent && policy === POLICY_NO_COOKIE) {
+      deleteCookie(SHOPIFY_Y, domain);
+      deleteCookie(SHOPIFY_S, domain);
+      return;
+    }
+
     const cookies = getShopifyCookies(document.cookie);
+
+    let maxage: number | undefined;
+    if (policy === POLICY_SHORT_TERM) {
+      maxage = shortTermLength;
+    } else if (policy === POLICY_SESSIONIZED) {
+      maxage = undefined;
+    }
 
     /**
      * Set user and session cookies and refresh the expiry time
@@ -28,25 +85,34 @@ export function useShopifyCookies(hasUserConsent = false, domain = ''): void {
     setCookie(
       SHOPIFY_Y,
       cookies[SHOPIFY_Y] || buildUUID(),
-      hasUserConsent ? longTermLength : shortTermLength,
-      domain
+      domain,
+      hasUserConsent ? longTermLength : maxage
     );
     setCookie(
       SHOPIFY_S,
       cookies[SHOPIFY_S] || buildUUID(),
-      shortTermLength,
-      domain
+      domain,
+      hasUserConsent ? shortTermLength : maxage
     );
+  });
+}
+
+function deleteCookie(name: string, domain: string) {
+  document.cookie = stringify(name, '', {
+    domain,
+    path: '/',
+    expires: new Date('1970-01-01T00:00:00.000Z'),
   });
 }
 
 function setCookie(
   name: string,
   value: string,
-  maxage: number,
-  domain: string
+  domain: string,
+  maxage?: number
 ): void {
   document.cookie = stringify(name, value, {
+    // undefined maxage and expires create a session cookie
     maxage,
     domain,
     samesite: 'Lax',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Contributes to Shopify/oxygen-platform/issues/841
Fixes Shopify/oxygen-platform/issues/846

Adds support for several cookie retention policies in case no consent is given.
Allows merchants to choose the semantics of a refused consent, according to their policies and regulations. While retaining backwards compatibility, it introduces a more compliant policy that won't set the cookie, and adds support for sessionized cookies which Shopify currently offers in Online Store as one of the policies for no-consent case.

### Additional context

This contributes to https://vault.shopify.io/gsd/projects/32297

---

### Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guidelines](https://github.com/shopify/storefront-kit/blob/main/contributing.md)
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
- [ ] Update docs in this repository according to your change
- [ ] Run `yarn changeset add` if this PR cause a version bump based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/). If you have a breaking change, it will need to wait until the next major version release. Otherwise, use patch updates even for new features. Read [more about Storefront Kit's versioning](https://github.com/shopify/storefront-kit/blob/main/readme.md#versioning).
