### PR TITLE
Update the SFAPI docs to use satisfies

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -189,17 +189,17 @@ Storefront Kit ships with generated TypeScript types that match the Storefront A
 ```ts
 import type {Product} from '@shopify/storefront-kit-react/storefront-api-types';
 
-const product: Product = {};
+const product = {} satisfies Product;
 ```
 
 You can also use TypeScript's built-in helpers to create your own Types to fit your needs:
 
 ```ts
-const partialProduct: Partial<Product> = {};
+const partialProduct = {} satisfies Partial<Product>;
 
 const productTitle: Pick<Product, 'title'> = '';
 
-const productExceptTitle: Omit<Product, 'title'> = {};
+const productExceptTitle = {} satisfies Omit<Product, 'title'>;
 ```
 
 ### GraphQL CodeGen

--- a/packages/react/src/storefront-api-types.doc.ts
+++ b/packages/react/src/storefront-api-types.doc.ts
@@ -17,7 +17,9 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   description: `
-    If you are using TypeScript, Hydrogen React ships with pre-generated TypeScript types that match the Storefront API's GraphQL schema.
+    If you are using TypeScript, Hydrogen React ships with pre-generated TypeScript types that match the Storefront API's GraphQL schema. These types can be used when you need to manually create an object that matches a Storefront API object's shape.
+
+    These types also work really well with the new [\`satisfies\` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) introduced in TypeScript 4.9, though you don't need to use \`satisfies\` to use these types.
   `,
   type: 'utility',
   defaultExample: {
@@ -27,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
         {
           title: 'Storefront API Types in TypeScript',
           code: './storefront-api-types.example.tsx',
-          language: 'tsx',
+          language: 'ts',
         },
       ],
       title: 'Example code',

--- a/packages/react/src/storefront-api-types.example.tsx
+++ b/packages/react/src/storefront-api-types.example.tsx
@@ -3,10 +3,17 @@ import type {
   Collection,
 } from '@shopify/storefront-kit-react/storefront-api-types';
 
-// @ts-expect-error - missing required fields
-const myProduct: Product = {id: '123'};
-console.log(myProduct.id);
+const myProduct = {id: '123', title: 'My Product'} satisfies Partial<Product>;
+console.log(myProduct.title);
 
-// @ts-expect-error - missing required fields
-const myCollection: Collection = {id: '123'};
-console.log(myCollection.id);
+const myCollection = {
+  id: '456',
+  title: 'My Collection',
+} satisfies Partial<Collection>;
+console.log(myCollection.title);
+
+const myNotSatisfyingProduct: Partial<Product> = {
+  id: '789',
+  title: 'Other Product',
+};
+console.log(myNotSatisfyingProduct.title);


### PR DESCRIPTION
Realized last night that `satisfies` is actually a perfect use-case for the SFAPI types we provide, and wanted to document it here. 