### PR TITLE
Fix UMD builds by defining process.env.NODE_ENV

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -34,6 +34,8 @@ export default defineConfig(({mode, ssrBuild}) => {
       define: {
         __HYDROGEN_DEV__: mode === 'umdbuilddev',
         __HYDROGEN_TEST__: false,
+        'process.env.NODE_ENV':
+          mode === 'umdbuilddev' ? '"development"' : '"production"',
       },
       plugins: [
         react({


### PR DESCRIPTION
While using the UMD build, the `process.env.NODE_ENV` wasn't being compiled away (and therefore breaking when being used in the browser). This will now compile it away, and make it either `development` or `production` based on the `mode`. 